### PR TITLE
Add visit and reload

### DIFF
--- a/src/Native/Navigation.js
+++ b/src/Native/Navigation.js
@@ -32,11 +32,9 @@ function replaceState(url)
 
 function reloadPage(skipCache)
 {
-	var location = document.location;
-
 	return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 	{
-		location.reload(skipCache);
+		document.location.reload(skipCache);
 		callback(_elm_lang$core$Native_Scheduler.succeed(_elm_lang$core$Native_Utils.Tuple0));
 	});
 }

--- a/src/Native/Navigation.js
+++ b/src/Native/Navigation.js
@@ -30,6 +30,17 @@ function replaceState(url)
 	});
 }
 
+function reloadPage(skipCache)
+{
+	var location = document.location;
+
+	return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
+	{
+		location.reload(skipCache);
+		callback(_elm_lang$core$Native_Scheduler.succeed(_elm_lang$core$Native_Utils.Tuple0));
+	});
+}
+
 function setLocation(url)
 {
 	return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
@@ -63,6 +74,7 @@ function getLocation()
 return {
 	go: go,
 	setLocation: setLocation,
+	reloadPage: reloadPage,
 	pushState: pushState,
 	replaceState: replaceState,
 	getLocation: getLocation

--- a/src/Native/Navigation.js
+++ b/src/Native/Navigation.js
@@ -43,7 +43,16 @@ function setLocation(url)
 {
 	return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
 	{
-		window.location = url;
+		try
+		{
+			window.location = url;
+		}
+		catch(err)
+		{
+			// Only Firefox can throw a NS_ERROR_MALFORMED_URI exception here.
+			// Other browsers reload the page, so let's be consistent about that.
+			document.location.reload(false);
+		}
 		callback(_elm_lang$core$Native_Scheduler.succeed(_elm_lang$core$Native_Utils.Tuple0));
 	});
 }

--- a/src/Native/Navigation.js
+++ b/src/Native/Navigation.js
@@ -30,6 +30,16 @@ function replaceState(url)
 	});
 }
 
+function setLocation(url)
+{
+	return _elm_lang$core$Native_Scheduler.nativeBinding(function(callback)
+	{
+		window.location = url;
+		callback(_elm_lang$core$Native_Scheduler.succeed(_elm_lang$core$Native_Utils.Tuple0));
+	});
+}
+
+
 function getLocation()
 {
 	var location = document.location;
@@ -52,6 +62,7 @@ function getLocation()
 
 return {
 	go: go,
+	setLocation: setLocation,
 	pushState: pushState,
 	replaceState: replaceState,
 	getLocation: getLocation

--- a/src/Navigation.elm
+++ b/src/Navigation.elm
@@ -1,5 +1,5 @@
 effect module Navigation where { command = MyCmd, subscription = MySub } exposing
-  ( back, forward, visit
+  ( back, forward, visit, reload
   , newUrl, modifyUrl
   , program, programWithFlags
   , Parser, makeParser, Location
@@ -16,7 +16,7 @@ request to your servers. Instead, you manage the changes yourself in Elm.
 @docs newUrl, modifyUrl
 
 # Navigation
-@docs back, forward, visit
+@docs back, forward, visit, reload
 
 # Start your Program
 @docs program, programWithFlags, Parser, makeParser, Location
@@ -168,6 +168,16 @@ visit url =
   command (Visit url)
 
 
+{-| Reload the current page. If passed `True`, instructs the browser not to
+use a cached version of the page.
+
+    -- Reload the page from the server, not using any cached versions.
+    reload True
+-}
+reload : Bool -> Cmd msg
+reload skipCache =
+  command (Reload skipCache)
+
 
 -- CHANGE HISTORY
 
@@ -255,6 +265,7 @@ type MyCmd msg
   | New String
   | Modify String
   | Visit String
+  | Reload Bool
 
 
 cmdMap : (a -> b) -> MyCmd a -> MyCmd b
@@ -271,6 +282,9 @@ cmdMap _ myCmd =
 
     Visit url ->
         Visit url
+
+    Reload skipCache ->
+        Reload skipCache
 
 
 type MySub msg =
@@ -341,6 +355,10 @@ cmdHelp router subs cmd =
     Visit url ->
       setLocation url
 
+    Reload skipCache ->
+      reloadPage skipCache
+
+
 
 notify : Platform.Router msg Location -> List (MySub msg) -> Location -> Task x ()
 notify router subs location =
@@ -361,6 +379,11 @@ spawnPopState router =
 setLocation : String -> Task x ()
 setLocation =
   Native.Navigation.setLocation
+
+
+reloadPage : Bool -> Task x ()
+reloadPage =
+  Native.Navigation.reloadPage
 
 
 go : Int -> Task x ()


### PR DESCRIPTION
Adds these based on prior discussion with @evancz:
- `visit : String -> Cmd msg` - the equivalent of `window.location = newUrl`
- `reload : Bool -> Cmd msg` - the equivalent of `document.reload(skipCache)`

I used `window.location = url` to implement `visit`. Based on my research, this is the most cross-browser compatible way to do it, more so than alternatives like `document.location = url` and `document.location.assign(url)` which purportedly do the same thing.

I couldn't find a way to get either of these to throw a runtime exception.
