### PR TITLE
Add headless program to reproduce Platform.program

### DIFF
--- a/src/Navigation.elm
+++ b/src/Navigation.elm
@@ -2,7 +2,7 @@ effect module Navigation where { command = MyCmd, subscription = MySub } exposin
   ( back, forward
   , load, reload, reloadAndSkipCache
   , newUrl, modifyUrl
-  , program, programWithFlags
+  , program, programWithFlags, headlessProgram
   , Location
   )
 
@@ -113,6 +113,38 @@ programWithFlags locationToMessage stuff =
     Html.programWithFlags
       { init = init
       , view = stuff.view
+      , update = stuff.update
+      , subscriptions = subs
+      }
+
+
+{-| Works the same as [`program`](#program), but it describes a headless program like
+[`Platform.program`][doc]
+
+[doc]: http://package.elm-lang.org/packages/elm-lang/core/latest/Platform#Program
+
+--}
+headlessProgram
+  : (Location -> msg)
+  ->
+    { init : Location -> (model, Cmd msg)
+    , update : msg -> model -> (model, Cmd msg)
+    , subscriptions : model -> Sub msg
+    }
+  -> Program Never model msg
+headlessProgram locationToMessage stuff =
+  let
+    subs model =
+      Sub.batch
+        [ subscription (Monitor locationToMessage)
+        , stuff.subscriptions model
+        ]
+
+    init =
+      stuff.init (Native.Navigation.getLocation ())
+  in
+    Platform.program
+      { init = init
       , update = stuff.update
       , subscriptions = subs
       }


### PR DESCRIPTION
Add `headlessProgram` which corresponds to `Platform.program` to allow the use of routing even in headless Elm applications.

A typical scenario would be when Elm is used as the business logic of a web app which has the view in React or Vue, for instance.

Fix #24