### PR TITLE
Allow `document` to be undefined for REPL support

### DIFF
--- a/src/Native/Navigation.js
+++ b/src/Native/Navigation.js
@@ -68,7 +68,7 @@ function setLocation(url)
 
 function getLocation()
 {
-	var location = document.location;
+	var location = (typeof document !== 'undefined') ? document.location : {};
 
 	return {
 		href: location.href,


### PR DESCRIPTION
The intent here is to fix Issue #7 without any further manual workarounds.

Previously, attempting to start elm-repl for a module that depends on Navigation would fail because `document` was undefined. This commit uses a dummy (empty object) value for the offending reference, preventing a crash.